### PR TITLE
Add support to configure abritrary Jetty server options...

### DIFF
--- a/src/de/otto/tesla/serving_with_jetty.clj
+++ b/src/de/otto/tesla/serving_with_jetty.clj
@@ -4,6 +4,11 @@
             [de.otto.tesla.stateful.handler :as handler]
             [clojure.tools.logging :as log]))
 
+(defn jetty-options [config]
+  (if-let [jetty-options (or (get config :jetty-options) (get-in config [:config :jetty-options]))]
+    jetty-options
+    {}))
+
 (defn port [config]
   (if-let [from-config (get-in config [:config :server-port])]
     (Integer. from-config)
@@ -14,9 +19,9 @@
   (start [self]
     (log/info "-> starting server")
     (let [all-routes (handler/handler handler)
-          server (jetty/run-jetty all-routes {:port (port config) :join? false})]
+          options (jetty-options (:config self))
+          server (jetty/run-jetty all-routes (merge {:port (port config) :join? false} options))]
       (assoc self :jetty server)))
-
   (stop [self]
     (log/info "<- stopping server")
     (if-let [server (:jetty self)]

--- a/test/de/otto/tesla/serving_with_jetty_test.clj
+++ b/test/de/otto/tesla/serving_with_jetty_test.clj
@@ -37,3 +37,18 @@
               started (system/start system-with-server)
               _ (system/stop started)]
           (is (= #{:config :handler :jetty :dummy-page} (into #{} (keys (:server started))))))))))
+
+(deftest use-configurator
+  (testing "using the configurator from config"
+    (let [jetty-config (atom nil)]
+      (with-redefs [jetty/run-jetty (fn [_ config]
+                                      (reset! jetty-config config) nil)]
+        (let [my-configurator identity
+              system-with-server (with-jetty/add-server (system/base-system {:jetty-options {:configurator my-configurator}}))
+              started (system/start system-with-server)
+              stop (system/stop started)]
+          (is (= (:configurator @jetty-config) my-configurator))
+          ))))
+
+  (testing "configurator should be extracted from config"
+    (is (= (with-jetty/jetty-options {:jetty-options {:configurator "test"}}) {:configurator "test"}))))


### PR DESCRIPTION
 in the runtime-config. This allows e.g. adding a custom configurator like gzip handling to the server.
